### PR TITLE
Avoid duplicate internal subsets.

### DIFF
--- a/xml/xml-parse.lisp
+++ b/xml/xml-parse.lisp
@@ -2617,7 +2617,9 @@
               (let ((xi2 (xstream-open-extid effective-extid)))
 		(with-zstream (zi2 :input-stack (list xi2))
 		  (ensure-dtd)
-                  (sax:start-internal-subset (handler *ctx*))
+                  ;; Avoid duplicate internal subsets.
+                  (unless (ignore-errors (have-internal-subset (handler *ctx*)))
+                    (sax:start-internal-subset (handler *ctx*)))
 		  (p/ext-subset zi2)
 		  (when (and fresh-dtd-p
 			     *cache-all-dtds*


### PR DESCRIPTION
I added this change to the previous pull request, but it didn't get merged, I assume because I added it late and it was overlooked. It fixes a bug introduced by the previous fix to DTD embedding, which can result in errors due to duplicate internal subsets and breaks ~60 tests in the SAX test suite (it does not affect Klacks).