### PR TITLE
Bug fix: guard against left recursion in DTDs.

### DIFF
--- a/xml/xml-parse.lisp
+++ b/xml/xml-parse.lisp
@@ -2224,6 +2224,8 @@
                  (t nil))))
       #'doit)))
 
+(defvar *left-recursion* nil)
+
 (defun compile-content-model (cspec &optional (continuation #'cmodel-done))
   (if (vectorp cspec)
       (lambda (actual-name)
@@ -2251,9 +2253,11 @@
         (*
           (let (maybe-continuation)
             (labels ((recurse (actual-name)
-                       (if (null actual-name)
+                       (if (or (null actual-name)
+                               *left-recursion*)
                            (funcall continuation actual-name)
-                           (or (funcall maybe-continuation actual-name)
+                           (or (let ((*left-recursion* t))
+                                 (funcall maybe-continuation actual-name))
                                (funcall continuation actual-name)))))
               (setf maybe-continuation
                     (compile-content-model (second cspec) #'recurse))


### PR DESCRIPTION
This is my suggested fix to the problem discussed in #9.
I don't have a good understanding of the function patched but have merely tried to copy the essence of the fix mentioned by ruricolist and made some personal tests. 