### PR TITLE
Issue #11: Fix incorrect type declaration in rod-hash-get

### DIFF
--- a/xml/xml-parse.lisp
+++ b/xml/xml-parse.lisp
@@ -370,7 +370,7 @@
                  (rod-hashtable-size hashtable))))
     (dolist (q (svref (rod-hashtable-table hashtable) j)
                (values nil nil nil))
-      (declare (type cons q))
+      (declare (type list q))
       (when (rod=** (car q) rod 0 (length (the (simple-array rune (*)) (car q))) start end)
         (return (values (cdr q) t (car q)))))))
 


### PR DESCRIPTION
Add possibility for the variable q to be nil.